### PR TITLE
Use flussonic-transcoder apt package instead of old flussonic-ffmpeg …

### DIFF
--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -5,7 +5,7 @@ describe "Flussonic VOD setup" do
     it { should be_installed }
   end
 
-  package('flussonic-ffmpeg') do
+  package('flussonic-transcoder') do
     it { should be_installed }
   end
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     state: latest
   with_items:
     - flussonic
-    - flussonic-ffmpeg
+    - flussonic-transcoder
     - flussonic-python
 
 - name: Make sure flussonic system user exists


### PR DESCRIPTION
…which now conflicts with a flussonic install (which installs flussonic-transcoder-base with a conflict with flussonic-ffmpeg).

In accordance with latest docs https://flussonic.com/doc/installation